### PR TITLE
fix package script on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "electron": "cross-env NODE_ENV=development electron .",
     "electron-production": "cross-env NODE_ENV=production electron .",
     "prepackage": "run-s clean:packages",
-    "package": "electron-packager ./ --out=./packages --icon=./dist/molecule.icns --ignore='/node_modules|src|tools|docs|webpackConfig|lock/'"
+    "package": "electron-packager ./ --out=./packages --icon=./dist/molecule.icns --ignore=\"/node_modules|src|tools|docs|webpackConfig|lock/\""
   },
   "dependencies": {
     "immutable": "^3.8.1",


### PR DESCRIPTION
Currently when trying to build the package on windows, it complains that `src command is not found`. Oddly enough, it's an issue with using single quotes around the `--ignore` argument's value 🙄 

Gotta love windows lol, but escaping double quotes allows the package script to work as expected.